### PR TITLE
disable decoding of attributes on parse

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,8 @@ Difference with cheerio:
 * Use `$.load(content)` to load HTML documents (e.g. missing `<html>` tags will be automatically emitted in this case).
 * Use `$(content)` to create HTML-fragments which can be later added to the loaded document.
 * Parser options (e.g. `xmlMode` and `normalizeWhitespace`) are missing since whacko is intended for spec compliant HTML parsing.
-* New parser option `encodeEntities` added. It disables HTML entities decoding on serialization.
+* New parser option `encodeEntities` added. When false, it disables HTML entities decoding on serialization.
+* New parser option `decodeHtmlEntities` added. When false, it disables HTML entities decoding on parse.
 
 In all other aspects it is the same with the [cheerio API](https://github.com/cheeriojs/cheerio#api).
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -3,7 +3,6 @@
  */
 var parse5 = require('parse5');
 
-var parser = new parse5.Parser(parse5.TreeAdapters.htmlparser2);
 
 /*
  Parser
@@ -28,6 +27,9 @@ var shouldParseAsDocument = function (content) {
 };
 
 exports.evaluate = function (content, options, isDocument) {
+    var parser = new parse5.Parser(parse5.TreeAdapters.htmlparser2, {
+        decodeHtmlEntities: options.decodeHtmlEntities !== false
+    });
     var dom = null;
 
     if (Buffer.isBuffer(content))

--- a/test/parse.js
+++ b/test/parse.js
@@ -18,6 +18,7 @@ var li = '<li class="durian">Durian</li>';
 // Attributes
 var attributes = '<img src="hello.png" alt="man waving">';
 var noValueAttribute = '<textarea disabled></textarea>';
+var encodedAttributes = '<img data-object="{&quot;foo&quot;:&quot;bar&quot;}">';
 
 // Comments
 var comment = '<!-- sexy -->';
@@ -91,6 +92,28 @@ describe('parse', function() {
       expect(attrs).to.be.ok();
       expect(attrs.src).to.equal('hello.png');
       expect(attrs.alt).to.equal('man waving');
+    });
+
+    it('should not decodeHtmlEntities if decodeHtmlEntities options is false', function() {
+      var attrs = parse.evaluate(encodedAttributes, {
+        'decodeHtmlEntities': false 
+      })[0].attribs;
+      expect(attrs).to.be.ok();
+      expect(attrs['data-object']).to.equal('{&quot;foo&quot;:&quot;bar&quot;}');
+    });
+
+    it('should decodeHtmlEntities if decodeHtmlEntities options is true', function() {
+      var attrs = parse.evaluate(encodedAttributes, {
+        'decodeHtmlEntities': true 
+      })[0].attribs;
+      expect(attrs).to.be.ok();
+      expect(attrs['data-object']).to.equal('{"foo":"bar"}');
+    });
+
+    it('should decodeHtmlEntities by default', function() {
+      var attrs = parse.evaluate(encodedAttributes, defaultOpts)[0].attribs;
+      expect(attrs).to.be.ok();
+      expect(attrs['data-object']).to.equal('{"foo":"bar"}');
     });
 
     it('should handle value-less attributes: ' + noValueAttribute, function() {


### PR DESCRIPTION
parse5 by default decodes element attributes when parsing them, but this behaviour is sometimes not desirable - for example, reactjs encodes its data attributes like so:
```html
   <div data-react-props="{&quot;count&quot;:0}" />
```