### PR TITLE
Update css-select dependency

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -1,5 +1,5 @@
 var _ = require('lodash'),
-    select = require('CSSselect'),
+    select = require('css-select'),
     utils = require('../utils'),
     domEach = utils.domEach,
     uniqueSort = require('domutils').uniqueSort,

--- a/lib/static.js
+++ b/lib/static.js
@@ -2,7 +2,7 @@
  * Module dependencies
  */
 
-var select = require('CSSselect'),
+var select = require('css-select'),
     parse = require('./parse'),
     render = require('./render'),
     _ = require('lodash');

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     },
     "dependencies": {
         "parse5": "^1.4.2",
-        "CSSselect": "~0.4.0",
-        "lodash": "~2.4.1",
+        "css-select": "~1.0.0",
+        "lodash": "~3.10.1",
         "domutils": "1.5"
     },
     "devDependencies": {


### PR DESCRIPTION
The CSSselect package has been renamed to css-select.

Installing wacko currently gives the following warnings:
> npm WARN deprecated CSSselect@0.4.1: the module is now available as 'css-select'
> npm WARN deprecated CSSwhat@0.4.7: the module is now available as 'css-what'

This change fixes those warnings and also updates the css-select dependency to the most recent version.