### PR TITLE
Replace deprecated package “CSSselect” with “css-select”

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -1,5 +1,5 @@
 var _ = require('lodash'),
-    select = require('CSSselect'),
+    select = require('css-select'),
     utils = require('../utils'),
     domEach = utils.domEach,
     uniqueSort = require('domutils').uniqueSort,

--- a/lib/static.js
+++ b/lib/static.js
@@ -2,7 +2,7 @@
  * Module dependencies
  */
 
-var select = require('CSSselect'),
+var select = require('css-select'),
     parse = require('./parse'),
     render = require('./render'),
     _ = require('lodash');

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "parse5": "^1.4.2",
-        "CSSselect": "~0.4.0",
+        "css-select": "^1.2.0",
         "lodash": "~2.4.1",
         "domutils": "1.5"
     },


### PR DESCRIPTION
Fix these two warnings:

    npm WARN deprecated CSSselect@0.4.1: the module is now available as 'css-select'
    npm WARN deprecated CSSwhat@0.4.7: the module is now available as 'css-what'

This fixes inikulin/whacko#17.