### PR TITLE
Upgrade package “lodash” to a non-deprecated version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dependencies": {
         "parse5": "^1.4.2",
         "css-select": "^1.2.0",
-        "lodash": "~2.4.1",
+        "lodash": "^3.10.1",
         "domutils": "1.5"
     },
     "devDependencies": {


### PR DESCRIPTION
Fix this warning:

```
npm WARN deprecated lodash@2.4.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^3.0.0.
```
